### PR TITLE
Fix ArgumentException on ComObject disposing

### DIFF
--- a/LottieSharp/PathMeasure.cs
+++ b/LottieSharp/PathMeasure.cs
@@ -134,7 +134,10 @@ namespace LottieSharp
                     }
                     else
                     {
-                        System.Runtime.InteropServices.Marshal.ReleaseComObject(_geometry);
+                        if (System.Runtime.InteropServices.Marshal.IsComObject(_geometry))
+                        {
+                            System.Runtime.InteropServices.Marshal.ReleaseComObject(_geometry);
+                        }
                     }
                 }
                 catch (Exception)


### PR DESCRIPTION
Add check before trying to release a non ComObject object to prevent an ArgumentException.