### PR TITLE
Add support for .NET Framework 4.x

### DIFF
--- a/src/LottieSharp/LottieSharp.WPF.Demo/LottieSharp.WPF.Demo.csproj
+++ b/src/LottieSharp/LottieSharp.WPF.Demo/LottieSharp.WPF.Demo.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net47</TargetFrameworks>
+	<LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>

--- a/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
+++ b/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
@@ -7,15 +7,15 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>lottie_sharp.ico</ApplicationIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	  <PackageLicenseExpression>MIT</PackageLicenseExpression>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>lottie_sharp_rect-128.png</PackageIcon>
     <RepositoryUrl>https://github.com/quicoli/LottieSharp</RepositoryUrl>
-	  <Version>2.2.0</Version>
-	  <Platforms>AnyCPU</Platforms>
-	  <AssemblyName>LottieSharp</AssemblyName>
-	  <PackageReadmeFile>readme.md</PackageReadmeFile>
-	  <PackageTags>wpf;lottie;animation;c-sharp</PackageTags>
-	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+	<Version>2.2.0</Version>
+	<Platforms>AnyCPU</Platforms>
+	<AssemblyName>LottieSharp</AssemblyName>
+	<PackageReadmeFile>readme.md</PackageReadmeFile>
+	<PackageTags>wpf;lottie;animation;c-sharp</PackageTags>
+	<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 	
 

--- a/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
+++ b/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFrameworks>net6.0-windows;net47</TargetFrameworks>
+	<LangVersion>Latest</LangVersion>
     <Nullable>disable</Nullable>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>lottie_sharp.ico</ApplicationIcon>


### PR DESCRIPTION
This PR adds the TFM 'net47' to add support for the classic .NET Framework 4.x series.