### PR TITLE
Downgrade SkiaSharp libraries to 2.88.9

### DIFF
--- a/src/LottieSharp/LottieSharp.WPF.Demo/LottieSharp.WPF.Demo.csproj
+++ b/src/LottieSharp/LottieSharp.WPF.Demo/LottieSharp.WPF.Demo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>net8.0-windows;net47</TargetFrameworks>
-	<LangVersion>Latest</LangVersion>
+    <LangVersion>Latest</LangVersion>
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <Platforms>AnyCPU;x64</Platforms>
@@ -24,8 +24,6 @@
     <PackageReference Include="MaterialDesignColors" Version="2.0.6" />
     <PackageReference Include="MaterialDesignThemes" Version="4.5.0" />
     <PackageReference Include="Prism.Wpf" Version="8.1.97" />
-	<PackageReference Include="SkiaSharp.Skottie" Version="3.116.1" />
-	<PackageReference Include="SkiaSharp.Views.WPF" Version="3.116.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
+++ b/src/LottieSharp/LottieSharp.WPF/LottieSharp.WPF.csproj
@@ -2,33 +2,33 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0-windows;net47</TargetFrameworks>
-	<LangVersion>Latest</LangVersion>
+    <LangVersion>Latest</LangVersion>
     <Nullable>disable</Nullable>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>lottie_sharp.ico</ApplicationIcon>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>lottie_sharp_rect-128.png</PackageIcon>
     <RepositoryUrl>https://github.com/quicoli/LottieSharp</RepositoryUrl>
-	  <Version>2.4.2</Version>
-	  <Platforms>AnyCPU</Platforms>
-	  <AssemblyName>LottieSharp</AssemblyName>
-	  <PackageReadmeFile>readme.md</PackageReadmeFile>
-	  <PackageTags>wpf;lottie;animation;c-sharp</PackageTags>
-	  <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-	  <SignAssembly>True</SignAssembly>
-	  <AssemblyOriginatorKeyFile>..\LottieSharp.snk</AssemblyOriginatorKeyFile>
-	  <PackageId>$(AssemblyName)</PackageId>
-	  <Title>$(AssemblyName)</Title>
-	  <Authors>Quicoli</Authors>
+    <Version>2.4.2</Version>
+    <Platforms>AnyCPU</Platforms>
+    <AssemblyName>LottieSharp</AssemblyName>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageTags>wpf;lottie;animation;c-sharp</PackageTags>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\LottieSharp.snk</AssemblyOriginatorKeyFile>
+    <PackageId>$(AssemblyName)</PackageId>
+    <Title>$(AssemblyName)</Title>
+    <Authors>Quicoli</Authors>
   </PropertyGroup>
-	
+
 
   <ItemGroup>
     <Content Include="lottie_sharp.ico" />
   </ItemGroup>
 
-	
+
 
   <ItemGroup>
     <None Include="..\..\..\Images\lottie_sharp_rect-128.png">
@@ -43,8 +43,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="SkiaSharp.Skottie" Version="3.116.1" />
-    <PackageReference Include="SkiaSharp.Views.WPF" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp.Skottie" Version="2.88.9" />
+    <PackageReference Include="SkiaSharp.Views.WPF" Version="2.88.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes the issue that the library can't be used without warnings if the TargetFramework is not set to net8.0-windows10.0.19041 or higher (i.e. specific Windows SDK version).

This fixes #73 